### PR TITLE
Add naming convention doc

### DIFF
--- a/TEST.md
+++ b/TEST.md
@@ -1,3 +1,16 @@
 This is a markup document for the Pepper Design System.
 This keeps track of all components for Pepper for SwiftUI.
 The output is a Swift Package you can drop into any Xcode or Swift Playground project.
+
+## Component Naming Guidelines
+
+To keep the design system organized and discoverable, each component name includes the prefix `LT` followed by a version stamp.
+
+- **Prefix**: `LT` identifies components that belong to Lextech.
+- **Date**: Use `YYYY-MMDD` to mark the creation date. For example, a component created on May 14, 2025 receives `2025-0514`.
+- **Multiple Versions**: If more than one version is created on the same day, append a lowercase letter in alphabetical order, such as `2025-0514a`, `2025-0514b`, and so on.
+
+Example: `LTButton-2025-0514a` denotes the first revision of the button component created on May 14, 2025.
+
+These naming conventions help prevent conflicts, clarify version history, and communicate ownership at a glance.
+


### PR DESCRIPTION
## Summary
- document naming conventions for design system components

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest` *(fails: command not found)*